### PR TITLE
fix: feedbacks for CIV-542

### DIFF
--- a/src/app/modules/glossary/glossary.component.html
+++ b/src/app/modules/glossary/glossary.component.html
@@ -3,7 +3,7 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <div class="title">{{'Legal Terms Simplified' | translate}}</div>
+        <h1 class="title">{{'Legal Terms Simplified' | translate}}</h1>
         <div class="pointer" (click)="closeModal()"><img src="assets/images/close.svg" alt="close"></div>
       </div>
       <div class="modal-body">
@@ -20,7 +20,7 @@
           </button>
           <div class="glossary-wrapper__icon">
             Powered By:
-            <img src="assets/images/nyaaya.svg" alt="nyaaya">
+            <a href="https://bit.ly/33rz72e" target="_blank"><img src="assets/images/nyaaya.svg" alt="nyaaya"></a>
           </div>
         </div>
       </div>

--- a/src/app/modules/glossary/glossary.component.scss
+++ b/src/app/modules/glossary/glossary.component.scss
@@ -4,8 +4,11 @@
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  padding: 20px 50px;
-  background-color: #FFFFFF;
+  justify-content: space-between;
+  padding: 0px 50px;
+  margin-top: 20px;
+  font-family: 'Encode Sans';
+  background-color: #ffffff;
   &__item {
     display: flex;
     width: 100%;
@@ -15,14 +18,16 @@
 
     .legal-title {
       font-size: 16px;
-      font-weight: 700;
+      font-weight: bold;
+      line-height: 130.5%;
+      letter-spacing: 0.045em;
       color: $darker-gray;
       margin: 0;
     }
     .legal-description {
       font-size: 16px;
       font-weight: 400;
-      color: $light-gray;
+      color: $dark-gray;
       margin-bottom: 10px;
     }
   }
@@ -37,6 +42,7 @@
     font-size: 14px;
     height: 40px;
     font-weight: 600;
+    line-height: 17px;
     margin: 20px auto;
   }
   &__icon {
@@ -44,31 +50,49 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    font-weight: normal;
+    font-size: 16px;
+    line-height: 119.5%;
+    letter-spacing: 0.01em;
+    color: #909090;
+  }
+  @media screen and (max-width: 768px) {
+    width: 100%;
+    padding: 0;
   }
 }
 
 .modal-dialog {
-  min-width: 800px !important;
-  max-width: 900px !important;
+  width: 800px !important;
+  max-width: unset;
+  .modal-content {
+    border: 1px dashed #7b61ff;
+    box-sizing: border-box;
+    border-radius: 20px;
+    min-height: 332px;
+  }
   .modal-header {
     align-items: center !important;
     border-bottom: unset;
     text-align: center;
-    padding-top: 0.1rem;
+    padding-top: 1rem;
     .title {
       font-size: 30px;
-      font-weight: 600;
+      font-weight: bolder;
       color: $primary-color;
       margin: 0;
       width: 100%;
+      @media screen and (max-width: 768px) {
+        font-size: 24px;
+      }
     }
   }
-  .modal-body {
-
+  @media screen and (max-width: 768px) {
+    width: 100%;
   }
 }
 
 .align-center {
-display: flex !important;
-align-items: center;
+  display: flex !important;
+  align-items: center;
 }


### PR DESCRIPTION
- Embedded this hyperlink https://bit.ly/33rz72e to the Nyaya logo at the bottom right of the popup, such that the logo becomes clickable. 

- The spacing between the text and the borders is not consistent at the top and the bottom of the pop up. On Staging, the pop up has more spacing at the bottom i.e between the borders and the 'RETURN TO SUMMARY' bar. The spacing between the top border and the heading 'LEGAL TERMS SIMPLIFIED' is much less.
We will need the spacing to be consistent. _DONE_

- The heading 'LEGAL TERMS SIMPLIFIED' needs to be in Bold _MADE IT BOLDER_

- The text 'RETURN TO SUMMARY' is seen in Bold on the pop up. The design indicated it to be without the bold font. This change needs to be made **IN THE DESIGNS AS WELL IT'S BOLD**

- Can we have the text font consistent with the Figma design? Currently the text carrying the Glossary terms, is lighter in shade compared to the design **DONE**

- We have noticed that the shape of the pop up changes depending upon the number of characters in the text.
E.g.: If there is only one Glossary term to be included, the pop up appears longer width wise, whereas if there are more such terms added, the shape becomes more square like (like the design).
We would like the pop up to appear like a box (design as given in Figma) with the shape consistent irrespective of the characters placed. **HEIGHT WILL INCREASE WIDTH WILL REMAIN CONSTANT**

- Can we make the beveled edges of the pop up more distinct? In the design they appear more distinct than the actual pop up.
**-DONE**

- The pop up is not optimized for the mobile screen. I am attaching the screenshot of the way it is seen on a mobile device. Part of the pop up is not visible. This would have to be optimised.
**NO DESIGNS YET OPTIMISED**