### PR TITLE
Chore(CIV-569): added meta tag for CSP in index.html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -25,6 +25,18 @@
           content="Law makers will get reports of the feedback collected in their constituency with detailed data analysis.
           These reports will close the feedback loop for users, ensuring that all of their opinions on a Law are taken into consideration by lawmakers."/>
 
+  <!-- Content Security Policy -->
+  <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self' 'unsafe-inline'; 
+      img-src https://* 'self' data: https://storage.googleapis.com; 
+      style-src 'self' 'unsafe-inline' https://* https://fonts.googleapis.com https://client.crisp.chat https://unpkg.com; 
+      script-src 'self' 'unsafe-inline' 'unsafe-eval' https://* https://unpkg.com https://cdn.ckeditor.com https://edge.fullstory.com https://client.crisp.chat https://checkout.razorpay.com; 
+      connect-src 'self' 'unsafe-inline' https://* https://rs.fullstory.com https://api-staging.civis.vote wss://client.relay.crisp.chat sentry.io https://*.sentry.io *.sentry.io; 
+      font-src 'self' https://* https://fonts.gstatic.com https://client.crisp.chat;
+      frame-src 'self' https://* https://api.razorpay.com"
+      />
+             
   <link href="https://fonts.googleapis.com/css?family=Encode+Sans:400,500,600&display=swap" rel="stylesheet">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="stylesheet" href="https://unpkg.com/ngx-bootstrap/datepicker/bs-datepicker.css">


### PR DESCRIPTION
## What? 
Implemented CSP header.

## How?
According to [this](https://awesome.commutatus.com/resources/mozilla-score) guide, response header has been populated with CSP using the `helmet-csp` package in `server.js`.

# UPDATE:
Since `server.js` is not being used, added CSP in `<meta>` tag in `index.html` file.

Further external resources has been added.

## Screen shot
![image](https://user-images.githubusercontent.com/46138150/184330947-87b7379d-6105-46a5-b598-579f676ef90b.png)

