### PR TITLE
feat(CIV-653): Donate page redirection

### DIFF
--- a/src/app/modules/navbar/navbar.component.html
+++ b/src/app/modules/navbar/navbar.component.html
@@ -69,14 +69,11 @@
 
     <div class="app-navbar__right-item">
       <div class="nav-btns" *ngIf="currentUrl !== 'consultations-profile'">
-        <button class="btn btn-oval" (click)="donate()">
-          {{'Donate' | translate}}
-        </button>
-      </div>
-      <div class="nav-btns" *ngIf="currentUrl !== 'consultations-profile'">
-        <button class="btn btn-oval" (click)="submitConsultation()">
-          {{'Submit a Consultation' | translate}}
-        </button>
+        <a href="https://pages.razorpay.com/Civis">
+          <button class="btn btn-oval">
+            {{'Donate' | translate}}
+          </button>
+        </a>
       </div>
       <div class="nav-btns" *ngIf="!currentUser">
         <button class="btn btn-transparent auth-btn" (click)="onSignUp()">{{'Log In / Sign Up' | translate}}</button>
@@ -143,12 +140,11 @@
               {{'How Civis Works' | translate}}
             </button>
           <div class="nav-btn">
-            <button class="btn-oval" (click)="closeMenu(); donate()">
-              {{'Donate' | translate}}
-            </button>
-          </div>
-          <div class="nav-btn">
-            <button class="btn-oval" (click)="closeMenu(); submitConsultation()">{{'Submit a Consultation' | translate}}</button>
+            <a href="https://pages.razorpay.com/Civis">
+              <button class="btn-oval" (click)="closeMenu()">
+                {{'Donate' | translate}}
+              </button>
+            </a>
           </div>
           <div class="nav-btn" *ngIf="!currentUser">
             <button class="close-btn btn btn-transparent" (click)="closeMenu(); onSignUp()">
@@ -160,6 +156,3 @@
     </div>
   </div>
 </div>
-
-<app-confirm-email-modal *ngIf="showConfirmEmailModal" (close)="showConfirmEmailModal = false">
-</app-confirm-email-modal>

--- a/src/app/modules/navbar/navbar.component.scss
+++ b/src/app/modules/navbar/navbar.component.scss
@@ -192,11 +192,15 @@
         color: rgba(255, 255, 255, 0.7);
       }
 
-      @media screen and (max-width: 991px) {
-        display: none;
+        @media screen and (max-width: 991px) {
+          display: none;
+        }
       }
     }
-  }
+
+    .nav-btns:first-child {
+      display: block;
+    }
 
   .xs-logo {
     @media screen and (max-width: 991px) {
@@ -255,7 +259,7 @@
     .btn-oval {
       font-size: 14px;
       font-weight: bold;
-      background: rgba(14, 115, 185, 0.7) !important;
+      background: #F0653A !important;
       border-radius: 33px;
       color: #ffffff !important;
       margin-right: 15px;

--- a/src/app/modules/navbar/navbar.component.scss
+++ b/src/app/modules/navbar/navbar.component.scss
@@ -192,15 +192,16 @@
         color: rgba(255, 255, 255, 0.7);
       }
 
-        @media screen and (max-width: 991px) {
-          display: none;
-        }
+      @media screen and (max-width: 991px) {
+        display: none;
       }
     }
-
+    
     .nav-btns:first-child {
       display: block;
     }
+  }
+
 
   .xs-logo {
     @media screen and (max-width: 991px) {
@@ -259,7 +260,7 @@
     .btn-oval {
       font-size: 14px;
       font-weight: bold;
-      background: #F0653A !important;
+      background: #f0653a !important;
       border-radius: 33px;
       color: #ffffff !important;
       margin-right: 15px;

--- a/src/app/modules/navbar/navbar.component.ts
+++ b/src/app/modules/navbar/navbar.component.ts
@@ -44,7 +44,6 @@ export class NavbarComponent implements OnInit {
     },
   ];
   activeTab: string;
-  showConfirmEmailModal: boolean;
   consultationStatus: any;
 
   constructor(
@@ -225,22 +224,7 @@ export class NavbarComponent implements OnInit {
     }
   }
 
-  donate() {
-    this.router.navigateByUrl('/donate');
-  }
 
-  submitConsultation() {
-    if (!this.currentUser) {
-      this.router.navigateByUrl('/auth');
-      return;
-    } else {
-      if (this.currentUser && this.currentUser.confirmedAt) {
-        this.router.navigateByUrl('/consultations/new');
-      } else {
-        this.showConfirmEmailModal = true;
-      }
-    }
-  }
 
   onSignUp() {
     if (this.currentUrl === 'consultations-profile') {

--- a/src/app/shared/components/footer/footer.component.html
+++ b/src/app/shared/components/footer/footer.component.html
@@ -4,6 +4,7 @@
       <div class="left-item">
         <ul class="item-list">
           <li [routerLink]="['/about-us']">{{'About Us' | translate}}</li>
+          <li (click)="submitConsultation()">{{'Submit a Consultation' | translate}}</li>
           <a data-event="click-blog" href="https://medium.com/civis-vote" target="_blank" class="text-decoration-none">
             <li>{{'Blog' | translate}}</li>
           </a>
@@ -79,3 +80,6 @@
     </div>
   </footer>
 </div>
+
+<app-confirm-email-modal *ngIf="showConfirmEmailModal" (close)="showConfirmEmailModal = false">
+</app-confirm-email-modal>

--- a/src/app/shared/components/footer/footer.component.ts
+++ b/src/app/shared/components/footer/footer.component.ts
@@ -54,7 +54,6 @@ export class FooterComponent implements OnInit {
       this.router.navigateByUrl('/auth');
       return;
     } else {
-      console.log(this.currentUser, this.currentUser.confirmedAt);
       if (this.currentUser && this.currentUser.confirmedAt) {
         this.router.navigateByUrl('/consultations/new');
       } else {

--- a/src/app/shared/components/footer/footer.component.ts
+++ b/src/app/shared/components/footer/footer.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { CookieService } from 'ngx-cookie';
+import { UserService } from '../../services/user.service';
 
 @Component({
   selector: 'app-footer',
@@ -7,28 +9,58 @@ import { CookieService } from 'ngx-cookie';
   styleUrls: ['./footer.component.scss'],
 })
 export class FooterComponent implements OnInit {
-
   languages = [
     {
-    id: 'en',
-    name: 'English'
+      id: 'en',
+      name: 'English'
     },
     {
       id: 'hi',
       name: 'Hindi'
-    }
+    },
   ];
 
   selectedLanguage = 'en';
+  currentUser: any;
+  showConfirmEmailModal: boolean;
 
-  constructor(private _cookieService: CookieService) {
+  constructor(
+    private _cookieService: CookieService,
+    private router: Router,
+    private userService: UserService
+  ) {
     const currentLanguage = this._cookieService.get('civisLang');
     if (currentLanguage) {
       this.selectedLanguage = currentLanguage;
     }
-   }
+  }
 
   ngOnInit() {
+    this.getCurrentUser();
+  }
+
+  getCurrentUser() {
+    this.userService.userLoaded$.subscribe((data) => {
+      if (data) {
+        this.currentUser = this.userService.currentUser;
+      } else {
+        this.currentUser = null;
+      }
+    });
+  }
+
+  submitConsultation() {
+    if (!this.currentUser) {
+      this.router.navigateByUrl('/auth');
+      return;
+    } else {
+      console.log(this.currentUser, this.currentUser.confirmedAt);
+      if (this.currentUser && this.currentUser.confirmedAt) {
+        this.router.navigateByUrl('/consultations/new');
+      } else {
+        this.showConfirmEmailModal = true;
+      }
+    }
   }
 
   setLanguage() {
@@ -36,5 +68,4 @@ export class FooterComponent implements OnInit {
     window.location.reload();
     window.scrollTo(0, 0);
   }
-
 }

--- a/src/app/shared/components/shared-components.module.ts
+++ b/src/app/shared/components/shared-components.module.ts
@@ -23,6 +23,7 @@ import { CaseStudiesListComponent } from './case-studies-list/case-studies-list.
 import { AuthModalComponent } from './auth-modal/auth-modal.component';
 import { ModalModule } from 'ngx-bootstrap';
 import { ProfaneModalComponent } from './profane-modal/profane-modal.component';
+import { ConfirmEmailModule } from '../confirm-email-modal/confirm-email.module';
 
 @NgModule({
   declarations: [
@@ -41,6 +42,7 @@ import { ProfaneModalComponent } from './profane-modal/profane-modal.component';
     ProfaneModalComponent
   ],
   imports: [
+    ConfirmEmailModule,
     CommonModule,
     LinearLoaderModule,
     RouterModule,


### PR DESCRIPTION
# What?
1) Linking the Donate button to the Donate page URL created on [Razorpay](https://pages.razorpay.com/Civis). 
2) Removed ‘Submit a Consultation’ button from Header and added it to footer.

# How?
## Flows to be followed:
**For `Donate button`:**
Clicking on the `Donate` button to trigger this URL [Pay for Donate to Civis by CIVIS](https://bit.ly/3bwTO1f).

**For `Submit a Consultation`**
If the user is *signed in* -> the user gets directed to [Civis | Get your voice heard by lawmakers](https://www.civis.vote/consultations/new)
If the user is *not signed in* -> the user gets directed to the Login/Sign up page [Civis | Get your voice heard by lawmakers](https://www.civis.vote/auth/sign-up)

## Designs:
1) [Donate button mobile](https://www.figma.com/file/PbOuZNBCwsUiqyQ8oCihqr/Donate-button-mobile) & [Donate button desktop](https://www.figma.com/file/ecGwzX09OCaAs1AirQtyK5/Donate-button-desktop?node-id=0%3A1)
2) [Edited footer for Submit a Consultation](https://www.figma.com/file/IPdyZP9rn73M03GfuLRv6w/Edited-footer-for-Submit-a-Consultation?node-id=0%3A1)

# Screenshots:

[DESKTOP] Donate button in header with Submit a Consultation button removed:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/46138150/187238293-6f9d5283-2648-4f0d-89c3-1bc1e9ba360a.png">


[MOBILE] Donate button in mobile for logged in user:

<img width="1171" alt="image" src="https://user-images.githubusercontent.com/46138150/187238597-a44e9cc0-6313-442d-8b38-ba1663800704.png">


[MOBILE] Donate button in mobile when user has not logged in:

<img width="1167" alt="image" src="https://user-images.githubusercontent.com/46138150/187238676-042bb567-cd0b-4683-bf81-1efa7f4a898e.png">

[DESKTOP] Submit a Consultation in footer:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/46138150/187239264-541922e6-e98d-48c6-8081-e504bb88da1c.png">


