### PR TITLE
Feat(CIV-537): Removed unverified tag from consultation feedback report

### DIFF
--- a/src/app/modules/consultations/consultation-profile/summary-response-container/summary-response-container.component.html
+++ b/src/app/modules/consultations/consultation-profile/summary-response-container/summary-response-container.component.html
@@ -15,8 +15,7 @@
             <p class="regular-text bold-text m-0 ml-2">
               {{'Citizen Leader [Name undisclosed]' | translate}}
             </p>
-            <p class="unverified-text"  *ngIf="!response?.node?.isVerified" tooltip="The person who made this response has not verified their email address yet." >(Unverified)</p>
-          </div>
+        </div>
     </ng-template>
     <p class="text-16" *ngIf="!response?.node?.answers" [innerHTML]="response.node?.responseText"></p>
     <div *ngIf="response?.node?.answers">

--- a/src/app/modules/consultations/consultations-summary/consultations-summary.component.ts
+++ b/src/app/modules/consultations/consultations-summary/consultations-summary.component.ts
@@ -99,8 +99,8 @@ export class ConsultationsSummaryComponent implements OnInit {
 
   splitResponses(responsesList) {
     if (responsesList.length) {
-      this.annonymousResponses = responsesList.filter(response => (response.node.user === null || response.node.user === undefined));
-      this.publicResponses = responsesList.filter(response => response.node.user !== null);
+      this.annonymousResponses = responsesList.filter(response => !response.node.user);
+      this.publicResponses = responsesList.filter(response => response.node.user);
       this.publicResponsesLength = this.publicResponses.filter((response) => response.node.roundNumber === this.activeRoundNumber).length;
       this.annonymousResponsesLength =
       this.annonymousResponses.filter((response) => response.node.roundNumber === this.activeRoundNumber).length;


### PR DESCRIPTION
## What?
Removed unverified tag from consultation feedback report.

## Why?
The final Consultation Feedback report is referred to by government officials. The tag 'unverified' against the responses appears confusing for the recipient of the report. 

## Testing?

**Before:**
![CIV-537 Before](https://user-images.githubusercontent.com/38960952/187866581-973996c5-fe5b-4fbf-af77-e759e1edf4f5.png)

**After:**
![CIV-537 After](https://user-images.githubusercontent.com/38960952/187866654-3036f2bf-1063-4f2d-9d8f-a58cfa35d25b.png)
