### PR TITLE
Chore(CIV-569): added CSP using yml file

### DIFF
--- a/customHttp.yml
+++ b/customHttp.yml
@@ -1,0 +1,12 @@
+customHeaders:
+  - pattern: '**/*'
+    headers:
+      - key: Content-Security-Policy
+        value: >-
+          default-src 'self' 'unsafe-inline' https://* https://api.razorpay.com wss:; 
+          img-src https://* 'self' data: https://storage.googleapis.com; 
+          style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://client.crisp.chat https://unpkg.com https://*; 
+          script-src 'self' 'unsafe-eval' 'unsafe-inline' https://* 'sha256-C+IGLEBTrzg1cqDKPZqpHDyT8Xu0DaPNG2w4A4c/YwA=' 'sha256-5CHnVzl6ds4Czo4JIGZODmOQz6oAqOA2gFtZ5VbeqiY=' 'sha256-Uyj0M92yRd7fuZy0y0k0xpKoTyWNSDgZZXesLbzukrU=' https://unpkg.com https://www.google.com https://cdn.ckeditor.com https://edge.fullstory.com https://client.crisp.chat https://checkout.razorpay.com https://www.googletagmanager.com https://www.gstatic.com; 
+          connect-src 'self' 'unsafe-inline' https://* https://rs.fullstory.com https://api-staging.civis.vote wss://client.relay.crisp.chat sentry.io https://*.sentry.io *.sentry.io https://api.civis.vote; 
+          font-src 'self' https://* https://fonts.gstatic.com https://client.crisp.chat; 
+          frame-src 'self' https://* *.amazonaws.com https://api.razorpay.com; object-src 'self';


### PR DESCRIPTION
## What? 
Adding CSP header Implementation again.

## How?
According to [this](https://docs.aws.amazon.com/amplify/latest/userguide/custom-headers.html#custom-header-YAML-format) guide, the response header has been populated with CSP using the `customHttp.yml` file.

## Why?
`customHttp.yml` file was removed from `staging` branch due to master and staging branch sync changes. Hence, creating a new PR for the same.
