### PR TITLE
Fix(CIV-677): Fixed all responses being recorded as anonymous responses while using new sign up flow.

### DIFF
--- a/src/app/modules/consultations/consultation-profile/consultation-questionnaire/consultation-questionnaire.component.ts
+++ b/src/app/modules/consultations/consultation-profile/consultation-questionnaire/consultation-questionnaire.component.ts
@@ -422,7 +422,7 @@ export class ConsultationQuestionnaireComponent implements OnInit, AfterViewInit
     const consultationResponse =  {
       consultationId: this.profileData.id,
       satisfactionRating : this.responseFeedback,
-      visibility: this.responseVisibility && this.currentUser?.isVerified ? "shared" : "anonymous",
+      visibility: this.responseVisibility,
       //TODO: Profanity filter feature, remove condition when ready fo deployment to production
       responseStatus: !environment.production ? this.responseStatus : 0,
     };

--- a/src/app/modules/consultations/consultation-profile/read-respond/read-respond.component.ts
+++ b/src/app/modules/consultations/consultation-profile/read-respond/read-respond.component.ts
@@ -265,6 +265,7 @@ export class ReadRespondComponent implements OnInit {
     }
 
     consultationResponse.responseStatus = isProfane ? 1:0;
+    consultationResponse.visibility = consultationResponse.visibility && this.currentUser?.isVerified ? "shared" : "anonymous",
 
     this.apollo.mutate({
       mutation: SubmitResponseQuery,


### PR DESCRIPTION

## What?

All the responses to any consultation created by users using the new authentication flow are being recorded as anonymous responses even when the user is verified and has marked the response as a public response.

## Why?

Responses created by verified users and marked as a public response should be recorded as a shared response.

## How?

The problem is that we are checking if the user is verified and if the user has set the response visibility as public to set the final visibility of the response.
This step is performed before checking if the user is authenticated or not. So while using the new sign-up flow, the user is not authenticated always, therefore all the responses are being recorded as anonymous.

The solution here is to set the visibility of a response after the user is authenticated.

## Testing?

Tested for the following scenarios:

1. New Auth flow - Verified User - Public Response
2. New Auth flow - Verified User - Private Response
3. New Auth flow - UnVerified User - Public Response
4. New Auth flow - UnVerified User - Private Response
5. Old Auth flow - Verified User - Public Response
6. Old Auth flow - Verified User - Private Response
7. Old Auth flow - UnVerified User - Public Response
8. Old Auth flow - UnVerified User - Private Response

