### PR TITLE
Fix(CIV-677): Fixed all responses being recorded as anonymous responses while using new sign up flow.

### DIFF
--- a/src/app/modules/consultations/consultation-profile/consultation-questionnaire/consultation-questionnaire.component.ts
+++ b/src/app/modules/consultations/consultation-profile/consultation-questionnaire/consultation-questionnaire.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, Input, Output, EventEmitter, ViewChild, ElementRef, 
 import { FormGroup, FormBuilder, FormControl, Validators } from '@angular/forms';
 import { UserService } from 'src/app/shared/services/user.service';
 import { ConsultationsService } from 'src/app/shared/services/consultations.service';
-import { isObjectEmpty, checkPropertiesPresence, scrollToFirstError } from '../../../../shared/functions/modular.functions';
+import { isObjectEmpty, checkPropertiesPresence, scrollToFirstError, setResponseVisibility } from '../../../../shared/functions/modular.functions';
 import { atLeastOneCheckboxCheckedValidator } from 'src/app/shared/validators/checkbox-validator';
 import { Apollo } from 'apollo-angular';
 import { SubmitResponseQuery, ConsultationProfileCurrentUser, CreateUserCountRecord,UpdateUserCountRecord, UserCountUser } from '../consultation-profile.graphql';
@@ -422,7 +422,7 @@ export class ConsultationQuestionnaireComponent implements OnInit, AfterViewInit
     const consultationResponse =  {
       consultationId: this.profileData.id,
       satisfactionRating : this.responseFeedback,
-      visibility: this.responseVisibility && this.currentUser?.isVerified ? "shared" : "anonymous",
+      visibility: this.responseVisibility,
       //TODO: Profanity filter feature, remove condition when ready fo deployment to production
       responseStatus: !environment.production ? this.responseStatus : 0,
     };
@@ -486,6 +486,7 @@ export class ConsultationQuestionnaireComponent implements OnInit, AfterViewInit
 
   submitResponse(consultationResponse) {
     this.responseSubmitLoading = true;
+    consultationResponse.visibility = setResponseVisibility(consultationResponse.visibility, this.currentUser?.isVerified)
     this.apollo.mutate({
       mutation: SubmitResponseQuery,
       variables: {

--- a/src/app/modules/consultations/consultation-profile/consultation-questionnaire/consultation-questionnaire.component.ts
+++ b/src/app/modules/consultations/consultation-profile/consultation-questionnaire/consultation-questionnaire.component.ts
@@ -244,6 +244,7 @@ export class ConsultationQuestionnaireComponent implements OnInit, AfterViewInit
             this.showError = false;
           }
         } else {
+          //If user is not authenticated, showing auth modal and storing consultation respose object to local storage
           this.authModal = true;
           localStorage.setItem(
             'consultationResponse',
@@ -422,7 +423,7 @@ export class ConsultationQuestionnaireComponent implements OnInit, AfterViewInit
     const consultationResponse =  {
       consultationId: this.profileData.id,
       satisfactionRating : this.responseFeedback,
-      visibility: this.responseVisibility,
+      visibility: this.responseVisibility, // initial response visibility set by the user
       //TODO: Profanity filter feature, remove condition when ready fo deployment to production
       responseStatus: !environment.production ? this.responseStatus : 0,
     };

--- a/src/app/modules/consultations/consultation-profile/consultation-response-text/consultation-response-text.component.ts
+++ b/src/app/modules/consultations/consultation-profile/consultation-response-text/consultation-response-text.component.ts
@@ -17,6 +17,7 @@ import {
   isObjectEmpty,
   checkPropertiesPresence,
   scrollToFirstError,
+  setResponseVisibility
 } from 'src/app/shared/functions/modular.functions';
 import { Router } from '@angular/router';
 import { Apollo } from 'apollo-angular';
@@ -155,7 +156,7 @@ export class ConsultationResponseTextComponent
   getConsultationResponse() {
     const consultationResponse = {
       consultationId: this.consultationId,
-      visibility: this.responseVisibility && this.currentUser?.isVerified ? "shared" : "anonymous",
+      visibility: this.responseVisibility,
       responseText: this.responseText,
       //TODO: Profanity filter feature, remove condition when ready fo deployment to production
       responseStatus: !environment.production ? this.responseStatus : 0,
@@ -575,6 +576,7 @@ export class ConsultationResponseTextComponent
 
   submitResponse(consultationResponse) {
     this.responseSubmitLoading = true;
+    consultationResponse.visibility = setResponseVisibility(consultationResponse.visibility, this.currentUser?.isVerified)    
     this.apollo
       .mutate({
         mutation: SubmitResponseQuery,

--- a/src/app/modules/consultations/consultation-profile/consultation-response-text/consultation-response-text.component.ts
+++ b/src/app/modules/consultations/consultation-profile/consultation-response-text/consultation-response-text.component.ts
@@ -156,7 +156,7 @@ export class ConsultationResponseTextComponent
   getConsultationResponse() {
     const consultationResponse = {
       consultationId: this.consultationId,
-      visibility: this.responseVisibility,
+      visibility: this.responseVisibility, // initial response visibility set by the user
       responseText: this.responseText,
       //TODO: Profanity filter feature, remove condition when ready fo deployment to production
       responseStatus: !environment.production ? this.responseStatus : 0,
@@ -404,6 +404,7 @@ export class ConsultationResponseTextComponent
             this.showError = false;
           }
         } else {
+          //If user is not authenticated, showing auth modal and storing consultation respose object to local storage
           this.authModal = true;
           localStorage.setItem(
             'consultationResponse',

--- a/src/app/modules/consultations/consultation-profile/read-respond/read-respond.component.ts
+++ b/src/app/modules/consultations/consultation-profile/read-respond/read-respond.component.ts
@@ -260,6 +260,7 @@ export class ReadRespondComponent implements OnInit {
 
   submitConsultationResponse(consultationResponse:any = null, isProfane:boolean = false){
     if(!consultationResponse){
+      //after user has completed authentication step
       consultationResponse=JSON.parse(localStorage.getItem('consultationResponse'));
       localStorage.removeItem('consultationResponse');
     }

--- a/src/app/modules/consultations/consultation-profile/read-respond/read-respond.component.ts
+++ b/src/app/modules/consultations/consultation-profile/read-respond/read-respond.component.ts
@@ -10,7 +10,7 @@ import { map, filter } from 'rxjs/operators';
 import { ErrorService } from 'src/app/shared/components/error-modal/error.service';
 import { ConsultationsService } from 'src/app/shared/services/consultations.service';
 import { CookieService } from 'ngx-cookie';
-import { isObjectEmpty } from 'src/app/shared/functions/modular.functions';
+import { isObjectEmpty, setResponseVisibility } from 'src/app/shared/functions/modular.functions';
 import { ModalDirective } from 'ngx-bootstrap';
 import { profanityList } from 'src/app/graphql/queries.graphql';
 import { environment } from '../../../../../environments/environment';
@@ -265,6 +265,7 @@ export class ReadRespondComponent implements OnInit {
     }
 
     consultationResponse.responseStatus = isProfane ? 1:0;
+    consultationResponse.visibility = setResponseVisibility(consultationResponse.visibility, this.currentUser?.isVerified)
 
     this.apollo.mutate({
       mutation: SubmitResponseQuery,
@@ -434,6 +435,7 @@ export class ReadRespondComponent implements OnInit {
       }
     } else {
       localStorage.removeItem('consultationResponse');
+      consultationResponse.visibility = setResponseVisibility(consultationResponse.visibility, this.currentUser?.isVerified)
       this.apollo.mutate({
         mutation: SubmitResponseQuery,
         variables: {

--- a/src/app/shared/functions/modular.functions.ts
+++ b/src/app/shared/functions/modular.functions.ts
@@ -205,3 +205,6 @@ export const scrollToFirstError = (selector, element) => {
     }
 };
 
+export const setResponseVisibility = (responseVisibility, userVerificationStatus) => {
+    return responseVisibility && userVerificationStatus ? "shared" : "anonymous";
+}

--- a/src/app/shared/functions/modular.functions.ts
+++ b/src/app/shared/functions/modular.functions.ts
@@ -206,5 +206,6 @@ export const scrollToFirstError = (selector, element) => {
 };
 
 export const setResponseVisibility = (responseVisibility, userVerificationStatus) => {
+    //set final response visibility based on initial response visibility set by the user and user verification status
     return responseVisibility && userVerificationStatus ? "shared" : "anonymous";
 }


### PR DESCRIPTION
## What?

All the responses to any consultation created by users using the new authentication flow are being recorded as anonymous responses even when the user is verified and has marked the response as a public response.

## Why?

Responses created by verified users and marked as public response should be recorded as a shared response.

## How?

When a user submits a response, the response visibility is set to `shared` or `anonymous` based on two parameters:

1. If the user is **verified** or not
2. If the user has set response visibility to **public** or not

After that, it is checked if the user is authenticated or not. If the user is not authenticated, the response object is stored in local storage and an auth modal is shown to the user. After the user completes the authentication step, the response object is obtained from local storage, and an API request to create a response is made.

Now, as we are checking for authentication after we have set the visibility of the response, the status of user verification is always undefined, therefore response is always set to `anonymous`.

After this fix, only the status of response visibility set by the user is recorded in the response object initially, and the response visibility is reset after checking the authentication status and completing the authentication if required.

## Testing?

Tested for the following scenarios:

1. New Auth flow - Verified User - Public Response
4. New Auth flow - Verified User - Private Response
5. New Auth flow - UnVerified User - Public Response
6. New Auth flow - UnVerified User - Private Response
7. Old Auth flow - Verified User - Public Response
8. Old Auth flow - Verified User - Private Response
9. Old Auth flow - UnVerified User - Public Response
10. Old Auth flow - UnVerified User - Private Response

## Anything Else?
Currently, the logic for creating a response is present at multiple places resulting in a very bad developer experience and code duplicity. This should be resolved by creating a more streamlined flow.