### PR TITLE
Fix(CIV-695): Fixed users not being able to submit responses unless they click the checkbox.

### DIFF
--- a/src/app/modules/consultations/consultation-profile/consultation-questionnaire/consultation-questionnaire.component.ts
+++ b/src/app/modules/consultations/consultation-profile/consultation-questionnaire/consultation-questionnaire.component.ts
@@ -27,7 +27,7 @@ export class ConsultationQuestionnaireComponent implements OnInit, AfterViewInit
   currentUser: any;
   responseAnswers: any[];
   showError: boolean;
-  responseVisibility: any;
+  responseVisibility: boolean = false;
   longTextAnswer: any;
   templateText: any;
   templateId: any;

--- a/src/app/modules/consultations/consultation-profile/consultation-response-text/consultation-response-text.component.ts
+++ b/src/app/modules/consultations/consultation-profile/consultation-response-text/consultation-response-text.component.ts
@@ -55,7 +55,7 @@ export class ConsultationResponseTextComponent
   templateText: any;
   templateId: any;
   usingTemplate: boolean;
-  responseVisibility: any;
+  responseVisibility: boolean = false;
   customStyleAdded: any;
   responseFeedback: any;
   showConfirmEmailModal: boolean;


### PR DESCRIPTION
<!-- See https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ for more info -->
<!-- Remove any sections that are not needed before submitting the PR -->


## What?

Users not being able to submit responses in some cases unless they click the `Make my response public` checkbox at least once.

## Why?
Bug fix to enable users to submit responses without any issues.

## How?

In the response submission flow, there is a step to check if any field in the consultation response object is invalid, if any field is invalid response will not be submitted.
The default value of the `responseVisibility` variable is `undefined` and when a user submits a private response the value will remain `undefined`, which will be considered an invalid response, breaking the response submission flow.
I have changed the default value to `false` i.e a valid value to fix this issue.
