### PR TITLE
Feat(CIV-689): Enabling short nudge feature on prod

### DIFF
--- a/src/app/modules/consultations/consultation-list/consultation-list.component.ts
+++ b/src/app/modules/consultations/consultation-list/consultation-list.component.ts
@@ -76,7 +76,7 @@ export class ConsultationListComponent implements OnInit {
             this.loadingElements.consultationList = false;
             this.consultationListData = item;
             this.consultationListArray = item.data;
-            //TODO: Profanity filter feature, remove condition when ready fo deployment to production
+            //TODO: Sort consultations by city feature, remove condition when ready fo deployment to production
             if(!environment.production) {
               this.consultationListArray = this.sortConsulationList(item.data);
             }

--- a/src/app/modules/consultations/consultation-list/consultation-list.graphql.ts
+++ b/src/app/modules/consultations/consultation-list/consultation-list.graphql.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
 import { environment } from '../../../../environments/environment';
-//TODO: Profanity filter feature, remove condition when ready fo deployment to production
+//TODO: Sort consultations by city feature, remove condition when ready fo deployment to production
 //name field is added here to amke sure that fragment is not empty
 const fragments = environment.production ? gql `
     fragment ministryFields on Ministry {

--- a/src/app/modules/consultations/consultation-profile/consultation-questionnaire/consultation-questionnaire.component.html
+++ b/src/app/modules/consultations/consultation-profile/consultation-questionnaire/consultation-questionnaire.component.html
@@ -39,12 +39,8 @@
                   <div *ngIf="showError && questionnaireForm.controls[question.id].errors" class="error-msg text-left">This is a mandatory question and your response is required</div>
                 </div>
                 <div class="answer" [id]="'text-area-' + question.id" *ngIf="question.questionType === 'long_text'">
-                  <!-- TODO: Profanity filter feature, remove condition when ready fo deployment to production -->
-                  <div class="text-area" *ngIf="!environment.production">
+                  <div class="text-area" >
                     <textarea (input)="longTextAnswer = $event.target.value" placeholder="Type your answer here, please refrain from using profane words" [formControlName]="question.id" [(ngModel)]='userResponse'></textarea>
-                  </div>
-                  <div class="text-area" *ngIf="environment.production">
-                    <textarea (input)="longTextAnswer = $event.target.value" placeholder="Type your answer here" [formControlName]="question.id"></textarea>
                   </div>
                   <div *ngIf="showError && questionnaireForm.controls[question.id].errors" class="error-msg text-left">This is a mandatory question and your response is required</div> 
                 </div>
@@ -83,5 +79,4 @@
 </app-confirm-email-modal>
 
 <app-auth-modal *ngIf="authModal" [consultationId]="consultationId" (close)="authModal = false"></app-auth-modal>
-<!-- TODO: Profanity filter feature, remove condition when ready fo deployment to production -->
-<app-profane-modal *ngIf="isConfirmModal && !environment.production" [message]='confirmMessage' [showCancel]=false (close)='confirmed($event)'></app-profane-modal>
+<app-profane-modal *ngIf="isConfirmModal" [message]='confirmMessage' [showCancel]=false (close)='confirmed($event)'></app-profane-modal>

--- a/src/app/modules/consultations/consultation-profile/consultation-questionnaire/consultation-questionnaire.component.ts
+++ b/src/app/modules/consultations/consultation-profile/consultation-questionnaire/consultation-questionnaire.component.ts
@@ -55,6 +55,11 @@ export class ConsultationQuestionnaireComponent implements OnInit, AfterViewInit
   profaneWords = [];
   environment: any = environment;
 
+  get profanityCountGetter() {
+  //TODO: Profanity filter feature, remove when ready for deployment to production
+    return environment.production ? 0 : this.profanityCount;
+  }
+  
   constructor(private _fb: FormBuilder,
     private userService: UserService,
     private consultationService: ConsultationsService,
@@ -281,7 +286,7 @@ export class ConsultationQuestionnaireComponent implements OnInit, AfterViewInit
           userCount:{
             userId: this.currentUser.id,
             //TODO: Profanity filter feature, remove condition when ready fo deployment to production
-            profanityCount: !environment.production ? this.profanityCount: 0,
+            profanityCount: this.profanityCountGetter,
             shortResponseCount: 0
           }
          },
@@ -319,7 +324,7 @@ export class ConsultationQuestionnaireComponent implements OnInit, AfterViewInit
           userCount:{
           userId: this.currentUser.id,
           //TODO: Profanity filter feature, remove condition when ready fo deployment to production
-          profanityCount: !environment.production ? this.profanityCount: 0,
+          profanityCount: this.profanityCountGetter,
           shortResponseCount: this.userData.shortResponseCount
         }
       },

--- a/src/app/modules/consultations/consultation-profile/consultation-questionnaire/consultation-questionnaire.component.ts
+++ b/src/app/modules/consultations/consultation-profile/consultation-questionnaire/consultation-questionnaire.component.ts
@@ -27,7 +27,7 @@ export class ConsultationQuestionnaireComponent implements OnInit, AfterViewInit
   currentUser: any;
   responseAnswers: any[];
   showError: boolean;
-  responseVisibility: any;
+  responseVisibility: boolean = false;
   longTextAnswer: any;
   templateText: any;
   templateId: any;
@@ -219,8 +219,6 @@ export class ConsultationQuestionnaireComponent implements OnInit, AfterViewInit
       const consultationResponse = this.getConsultationResponse();
       if (!isObjectEmpty(consultationResponse)) {
         if (this.currentUser) {
-          //TODO: Profanity filter feature, remove condition when ready fo deployment to production
-          if(!environment.production){
             this.apollo.watchQuery({
               query: UserCountUser,
               variables: {userId:this.currentUser.id},
@@ -239,10 +237,6 @@ export class ConsultationQuestionnaireComponent implements OnInit, AfterViewInit
               const e = new Error(err);
                 this.errorService.showErrorModal(err);
             });
-          } else {
-            this.submitResponse(consultationResponse);
-            this.showError = false;
-          }
         } else {
           //If user is not authenticated, showing auth modal and storing consultation respose object to local storage
           this.authModal = true;
@@ -286,7 +280,8 @@ export class ConsultationQuestionnaireComponent implements OnInit, AfterViewInit
         variables:{
           userCount:{
             userId: this.currentUser.id,
-            profanityCount: this.profanityCount,
+            //TODO: Profanity filter feature, remove condition when ready fo deployment to production
+            profanityCount: !environment.production ? this.profanityCount: 0,
             shortResponseCount: 0
           }
          },
@@ -323,7 +318,8 @@ export class ConsultationQuestionnaireComponent implements OnInit, AfterViewInit
         variables:{
           userCount:{
           userId: this.currentUser.id,
-          profanityCount:this.profanityCount,
+          //TODO: Profanity filter feature, remove condition when ready fo deployment to production
+          profanityCount: !environment.production ? this.profanityCount: 0,
           shortResponseCount: this.userData.shortResponseCount
         }
       },
@@ -424,8 +420,7 @@ export class ConsultationQuestionnaireComponent implements OnInit, AfterViewInit
       consultationId: this.profileData.id,
       satisfactionRating : this.responseFeedback,
       visibility: this.responseVisibility, // initial response visibility set by the user
-      //TODO: Profanity filter feature, remove condition when ready fo deployment to production
-      responseStatus: !environment.production ? this.responseStatus : 0,
+      responseStatus: this.responseStatus,
     };
     if (checkPropertiesPresence(consultationResponse)) {
       consultationResponse['templateId'] = this.templateId;

--- a/src/app/modules/consultations/consultation-profile/consultation-response-text/consultation-response-text.component.html
+++ b/src/app/modules/consultations/consultation-profile/consultation-response-text/consultation-response-text.component.html
@@ -55,7 +55,6 @@
 </div>
 <app-confirm-email-modal *ngIf="showConfirmEmailModal" (close)="showConfirmEmailModal = false">
 </app-confirm-email-modal>
-<!-- TODO: Profanity filter feature, remove condition when ready fo deployment to production -->
-<app-profane-modal *ngIf="isConfirmModal && !environment.production" [message]='confirmMessage' [showCancel]=false (close)='confirmed($event)'></app-profane-modal>
-<app-profane-modal *ngIf="isResponseShort && !environment.production" [message]='responseMessage' [showCancel]=false (close)='confirmed($event)'></app-profane-modal>
+<app-profane-modal *ngIf="isConfirmModal" [message]='confirmMessage' [showCancel]=false (close)='confirmed($event)'></app-profane-modal>
+<app-profane-modal *ngIf="isResponseShort" [message]='responseMessage' [showCancel]=false (close)='confirmed($event)'></app-profane-modal>
 <app-auth-modal *ngIf="authModal" [consultationId]="consultationId" (close)="authModal = false"></app-auth-modal>

--- a/src/app/modules/consultations/consultation-profile/consultation-response-text/consultation-response-text.component.ts
+++ b/src/app/modules/consultations/consultation-profile/consultation-response-text/consultation-response-text.component.ts
@@ -55,7 +55,7 @@ export class ConsultationResponseTextComponent
   templateText: any;
   templateId: any;
   usingTemplate: boolean;
-  responseVisibility: any;
+  responseVisibility: boolean = false;
   customStyleAdded: any;
   responseFeedback: any;
   showConfirmEmailModal: boolean;
@@ -158,8 +158,7 @@ export class ConsultationResponseTextComponent
       consultationId: this.consultationId,
       visibility: this.responseVisibility, // initial response visibility set by the user
       responseText: this.responseText,
-      //TODO: Profanity filter feature, remove condition when ready fo deployment to production
-      responseStatus: !environment.production ? this.responseStatus : 0,
+      responseStatus: this.responseStatus,
       satisfactionRating: this.responseFeedback,
     };
     if (checkPropertiesPresence(consultationResponse)) {
@@ -377,8 +376,6 @@ export class ConsultationResponseTextComponent
       const consultationResponse = this.getConsultationResponse();
       if (!isObjectEmpty(consultationResponse)) {
         if (this.currentUser) {
-          //TODO: Profanity filter feature, remove condition when ready fo deployment to production
-          if(!environment.production){
             // this query fetches the data for the user
             this.apollo.watchQuery({
               query: UserCountUser,
@@ -399,10 +396,6 @@ export class ConsultationResponseTextComponent
               const e = new Error(err);
               this.errorService.showErrorModal(err);
             });
-          } else {
-            this.submitResponse(consultationResponse);
-            this.showError = false;
-          }
         } else {
           //If user is not authenticated, showing auth modal and storing consultation respose object to local storage
           this.authModal = true;
@@ -465,7 +458,8 @@ export class ConsultationResponseTextComponent
       variables:{
         userCount:{
           userId: this.currentUser.id,
-          profanityCount: this.userData.profanityCount,
+          //TODO: Profanity filter feature, remove condition when ready fo deployment to production
+          profanityCount: !environment.production ? this.userData.profanityCount: 0,
           shortResponseCount: this.shortResponseCount
         }
       },
@@ -506,7 +500,8 @@ export class ConsultationResponseTextComponent
         variables:{
           userCount:{
             userId: this.currentUser.id,
-            profanityCount: this.profanityCount,
+            //TODO: Profanity filter feature, remove condition when ready fo deployment to production
+            profanityCount: !environment.production ? this.profanityCount: 0,
             shortResponseCount: 0
           }
         },
@@ -551,7 +546,8 @@ export class ConsultationResponseTextComponent
       variables:{
         userCount:{
           userId: this.currentUser.id,
-          profanityCount: this.profanityCount,
+          //TODO: Profanity filter feature, remove condition when ready fo deployment to production
+          profanityCount: !environment.production ? this.profanityCount: 0,
           shortResponseCount: this.userData.shortResponseCount
         }
        },

--- a/src/app/modules/consultations/consultation-profile/consultation-response-text/consultation-response-text.component.ts
+++ b/src/app/modules/consultations/consultation-profile/consultation-response-text/consultation-response-text.component.ts
@@ -36,6 +36,7 @@ import { environment } from '../../../../../environments/environment';
 export class ConsultationResponseTextComponent
   implements OnInit, AfterViewChecked {
   @Input() profileData;
+  @Input() responseText: any;
   @ViewChild('responseIndex', { read: ElementRef, static: false })
   responseIndex: ElementRef<any>;
   @ViewChild('responseContainer', { read: ElementRef, static: false })
@@ -49,7 +50,6 @@ export class ConsultationResponseTextComponent
   currentUser: any;
   consultationId: any;
   isMobile = window.innerWidth <= 768;
-  responseText: any;
   showPublicResponseOption: boolean;
   showAutoSaved: boolean;
   templateText: any;

--- a/src/app/modules/consultations/consultation-profile/consultation-response-text/consultation-response-text.component.ts
+++ b/src/app/modules/consultations/consultation-profile/consultation-response-text/consultation-response-text.component.ts
@@ -85,6 +85,11 @@ export class ConsultationResponseTextComponent
   profaneWords = [];
   environment: any = environment;
 
+  get profanityCountGetter() {
+  //TODO: Profanity filter feature, remove when ready for deployment to production
+    return environment.production ? 0 : this.profanityCount;
+  }
+
   constructor(
     private userService: UserService,
     private consultationService: ConsultationsService,
@@ -501,7 +506,7 @@ export class ConsultationResponseTextComponent
           userCount:{
             userId: this.currentUser.id,
             //TODO: Profanity filter feature, remove condition when ready fo deployment to production
-            profanityCount: !environment.production ? this.profanityCount: 0,
+            profanityCount: this.profanityCountGetter,
             shortResponseCount: 0
           }
         },
@@ -547,7 +552,7 @@ export class ConsultationResponseTextComponent
         userCount:{
           userId: this.currentUser.id,
           //TODO: Profanity filter feature, remove condition when ready fo deployment to production
-          profanityCount: !environment.production ? this.profanityCount: 0,
+          profanityCount: this.profanityCountGetter,
           shortResponseCount: this.userData.shortResponseCount
         }
        },

--- a/src/app/modules/consultations/consultation-profile/read-respond/read-respond.component.html
+++ b/src/app/modules/consultations/consultation-profile/read-respond/read-respond.component.html
@@ -16,7 +16,7 @@
       </app-consultation-questionnaire>
     </div>
     <ng-template #responseTextContainer>
-      <app-consultation-response-text [profileData]="profileData" (openThankYouModal)="showThankYouModal = true; earnedPoints = $event"></app-consultation-response-text>
+      <app-consultation-response-text [profileData]="profileData" (openThankYouModal)="showThankYouModal = true; earnedPoints = $event" [responseText]="responseText"></app-consultation-response-text>
     </ng-template>
   </div>
   <div *ngIf="profileData?.reviewType !== 'policy'">

--- a/src/app/modules/consultations/consultation-profile/read-respond/read-respond.component.html
+++ b/src/app/modules/consultations/consultation-profile/read-respond/read-respond.component.html
@@ -26,9 +26,8 @@
 </section>
 <app-thank-you-modal *ngIf="showThankYouModal" [points]="earnedPoints" [profileData]="profileData" (closeThankYouModal)="onCloseThanksModal()">
 </app-thank-you-modal>
-<!-- TODO: Profanity filter feature, remove condition when ready fo deployment to production -->
-<app-profane-modal *ngIf="isConfirmModal && !environment.production" [message]='confirmMessage' [showCancel]=false (close)='confirmed($event)'></app-profane-modal>
-<app-profane-modal *ngIf="isResponseShort && !environment.production" [message]='responseMessage' [showCancel]=false (close)='confirmed($event)'></app-profane-modal>
+<app-profane-modal *ngIf="isConfirmModal" [message]='confirmMessage' [showCancel]=false (close)='confirmed($event)'></app-profane-modal>
+<app-profane-modal *ngIf="isResponseShort" [message]='responseMessage' [showCancel]=false (close)='confirmed($event)'></app-profane-modal>
 
 
 <div bsModal #emailVerificationModal="bs-modal" *ngIf="emailVerification" class="modal fade logout-confirm-modal" tabindex="-1"

--- a/src/app/modules/consultations/consultation-profile/read-respond/read-respond.component.ts
+++ b/src/app/modules/consultations/consultation-profile/read-respond/read-respond.component.ts
@@ -51,6 +51,7 @@ export class ReadRespondComponent implements OnInit {
   };
   isResponseShort = false;
   environment: any = environment;
+  responseText: any;
 
   @ViewChild('emailVerificationModal', { static: false }) emailVerificationModal: ModalDirective;
 
@@ -340,6 +341,7 @@ export class ReadRespondComponent implements OnInit {
       // if the response is profane then we discard the draft, otherwise it is submitted
       var Filter = require('bad-words'),
       filter = new Filter({list: this.profaneWords});
+      this.responseText = consultationResponse.responseText;
       if(filter.isProfane(consultationResponse.responseText.replace(/(<([^>]+)>)/gi, ""))){
         this.apollo.watchQuery({
           query: UserCountUser,

--- a/src/app/shared/components/profane-modal/profane-modal.component.scss
+++ b/src/app/shared/components/profane-modal/profane-modal.component.scss
@@ -19,6 +19,11 @@
     border: none;
     padding: 10px 15px;
 
+    @media screen and (max-width: 991px) {
+      width: 95%;
+      height: auto;
+    }
+
     .conf-modal--header {
       height: 35px;
       font-size: 16px;
@@ -29,6 +34,10 @@
       font-size: 14px;
       text-align: left;
       height: 50px;
+
+      @media screen and (max-width: 991px) {
+        height: auto;
+      }
     }
 
     .conf-modal--buttons {


### PR DESCRIPTION
## What?

The short nudge response feature was disabled in the production environment, enabled it.

## Why?
To provide users access to the short nudge feature.

## How?

1. Removed the conditions where we were checking for the environment and using different flows for staging and production environments.
2. As the profanity filter feature also uses the same API endpoints as this feature, added a condition to set `profanityCount` to `0` in the production environment.

## Testing?
Tested the following scenarios:
1. Short response nudge for a new user using old and new authentication flow.
2. Short response nudge for an existing user using old and new authentication flow.
3. Tested short response nudge in production mode as well.