### PR TITLE
chore(CIV-697): Added a nonce value for GTM script and google analytics as a script src in CSP

### DIFF
--- a/customHttp.yml
+++ b/customHttp.yml
@@ -6,7 +6,7 @@ customHeaders:
           default-src 'self' 'unsafe-inline' https://* https://api.razorpay.com wss:; 
           img-src https://* 'self' data: https://storage.googleapis.com; 
           style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://client.crisp.chat https://unpkg.com https://*; 
-          script-src 'self' 'unsafe-eval' 'unsafe-inline' https://* 'sha256-C+IGLEBTrzg1cqDKPZqpHDyT8Xu0DaPNG2w4A4c/YwA=' 'sha256-5CHnVzl6ds4Czo4JIGZODmOQz6oAqOA2gFtZ5VbeqiY=' 'sha256-Uyj0M92yRd7fuZy0y0k0xpKoTyWNSDgZZXesLbzukrU=' https://unpkg.com https://www.google.com https://cdn.ckeditor.com https://edge.fullstory.com https://client.crisp.chat https://checkout.razorpay.com https://www.googletagmanager.com https://www.gstatic.com; 
+          script-src 'self' 'unsafe-eval' 'unsafe-inline' https://* 'nonce-6A576D5A7134743777217A25432A462D' 'sha256-C+IGLEBTrzg1cqDKPZqpHDyT8Xu0DaPNG2w4A4c/YwA=' 'sha256-5CHnVzl6ds4Czo4JIGZODmOQz6oAqOA2gFtZ5VbeqiY=' 'sha256-Uyj0M92yRd7fuZy0y0k0xpKoTyWNSDgZZXesLbzukrU=' https://unpkg.com https://www.google.com https://cdn.ckeditor.com https://edge.fullstory.com https://client.crisp.chat https://checkout.razorpay.com https://www.googletagmanager.com https://www.gstatic.com https://www.google-analytics.com; 
           connect-src 'self' 'unsafe-inline' https://* https://rs.fullstory.com https://api-staging.civis.vote wss://client.relay.crisp.chat sentry.io https://*.sentry.io *.sentry.io https://api.civis.vote; 
           font-src 'self' https://* https://fonts.gstatic.com https://client.crisp.chat; 
           frame-src 'self' https://* *.amazonaws.com https://api.razorpay.com; object-src 'self';

--- a/src/app/shared/services/starter.service.ts
+++ b/src/app/shared/services/starter.service.ts
@@ -23,6 +23,7 @@ export class StarterService {
         const GTMKey = environment.production ? 'GTM-5SHVQF8' : '';
         if (GTMKey) {
             const tagManagerScript = this.renderer.createElement('script');
+            tagManagerScript.setAttribute("nonce","6A576D5A7134743777217A25432A462D")
             tagManagerScript.innerHTML =
                 `(function (w, d, s, l, i) {
                     w[l] = w[l] || []; w[l].push({


### PR DESCRIPTION

## What does this change do?

Added a nonce value for GTM script and google analytics as a script-src in CSP

## Why is this change needed?

GTM script was being blocked by CSP as it is an inline script, added a nonce attribute to whitelist the script.

## How were the changes done?

Generated a 128-bit cryptographic key and added it as a nonce value for the GTM script.

## How was testing done?

Tested the CSP configuration by adding meta tags for the `script-src` CSP policy.
