### PR TITLE
Fix(PRO-361): Fixed reponse text overwritten in consultions with more than one subjective questions.

### DIFF
--- a/src/app/modules/consultations/consultation-profile/consultation-questionnaire/consultation-questionnaire.component.html
+++ b/src/app/modules/consultations/consultation-profile/consultation-questionnaire/consultation-questionnaire.component.html
@@ -40,7 +40,7 @@
                 </div>
                 <div class="answer" [id]="'text-area-' + question.id" *ngIf="question.questionType === 'long_text'">
                   <div class="text-area" >
-                    <textarea (input)="longTextAnswer = $event.target.value" placeholder="Type your answer here, please refrain from using profane words" [formControlName]="question.id" [(ngModel)]='userResponse'></textarea>
+                    <textarea (input)="longTextAnswer = $event.target.value" placeholder="Type your answer here, please refrain from using profane words" [formControlName]="question.id" ></textarea>
                   </div>
                   <div *ngIf="showError && questionnaireForm.controls[question.id].errors" class="error-msg text-left">This is a mandatory question and your response is required</div> 
                 </div>

--- a/src/app/modules/consultations/consultation-profile/consultation-questionnaire/consultation-questionnaire.component.ts
+++ b/src/app/modules/consultations/consultation-profile/consultation-questionnaire/consultation-questionnaire.component.ts
@@ -46,7 +46,6 @@ export class ConsultationQuestionnaireComponent implements OnInit, AfterViewInit
     title: ''
   };
   nudgeMessageDisplayed= false;
-  userResponse='';
   profanityCount: any;
   userData:any;
   profanity_count_changed: boolean=false;
@@ -264,8 +263,7 @@ export class ConsultationQuestionnaireComponent implements OnInit, AfterViewInit
     var Filter = require('bad-words'),
     filter = new Filter({list: this.profaneWords});
 
-    this.isUserResponseProfane=filter.isProfane(this.userResponse);
-
+    this.isUserResponseProfane=filter.isProfane(this.longTextAnswer);
     if (this.userData!==null){
       this.profanityCount=this.userData.profanityCount;
     }


### PR DESCRIPTION

## What does this change do?

Fixes response-text overwriting in consultations with more than one subjective question.
[A video demonstrating the issue](https://videos.commutatus.com/videos/civis-pro-361)

## Why is this change needed?

Bug Fix

## How were the changes done?

The bug was occurring due to two-way data binding of the `userResponse` variable with the `textarea` element, removing the two-way data binding as it is redundant.

## How was testing done?

Tested manually to verify that the feature is working as expected for consultations with more than one subjective question.