### PR TITLE
Fix(PRO-400): Fixed bug in response submission flow in consultations with MCQs with Others option

### DIFF
--- a/src/app/modules/consultations/consultation-profile/consultation-questionnaire/consultation-questionnaire.component.ts
+++ b/src/app/modules/consultations/consultation-profile/consultation-questionnaire/consultation-questionnaire.component.ts
@@ -459,6 +459,9 @@ export class ConsultationQuestionnaireComponent implements OnInit, AfterViewInit
         this.questions.forEach(ques => {
           if (question.id === ques.id) {
             ques.is_other = false;
+            if(this.questionnaireForm.controls['other_answer-'+ques.id]){
+              this.questionnaireForm.removeControl('other_answer-' + ques.id)
+            }
           }
         });
       }


### PR DESCRIPTION

## What does this change do?

Bug Fix

## Why is this change needed?

To resolve the bug in the consultation response submission flow.

## How were the changes done?

For the MCQ-type questions with the `Other` option, when a user selects the `Other` option, an input box where the users have to manually enter their options is shown to the users. A form control is added to validate the user has entered his/her response in the input box.
If the user decides to switch back to an existing option, the input box disappears but the form control for the input box is still present causing a validation error preventing the user to submit a response.

This change will remove the form validation for the `Other` input box if the user switches to an existing option.

## How was testing done?

Manually tested to verify that the flow is working as expected when the user first selects the Other option and then switches to another option.

