### PR TITLE
refactor: Move theme field from department to consultation level

### DIFF
--- a/src/app/modules/consultations/consultation-list/consultation-list.component.html
+++ b/src/app/modules/consultations/consultation-list/consultation-list.component.html
@@ -38,7 +38,7 @@
       <ng-container *ngFor="let item of closedConsultationList">
         <div class="table-body">
           <div class="cell-1 consultation-cell">
-            <img appDefaultImage [type]="'consultation-cover'" [src]="item.department?.theme?.coverPhoto?.url"
+            <img appDefaultImage [type]="'consultation-cover'" [src]="item?.theme?.coverPhoto?.url"
               class="avatar avatar--64 fit-cover" />
             <div class="c-profile-data">
               <p>{{ getTranslatedTitle(item) }}</p>
@@ -60,7 +60,7 @@
         <!-- list-mobile-layout -->
         <div class="table-list">
           <div class="list-grid">
-            <img appDefaultImage [type]="'consultation-cover'" [src]="item.department?.theme?.coverPhoto?.url"
+            <img appDefaultImage [type]="'consultation-cover'" [src]="item?.theme?.coverPhoto?.url"
               class="avatar avatar--42 fit-cover" />
             <div class="list-detail">
               <div class="c-profile-data">

--- a/src/app/modules/consultations/consultation-list/consultation-list.graphql.ts
+++ b/src/app/modules/consultations/consultation-list/consultation-list.graphql.ts
@@ -38,15 +38,15 @@ export const ConsultationList = gql`
           name
           odiaName
           marathiName
-          theme {
-            id
-            coverPhoto (resolution: "350X285") {
-              id
-              filename
-              url
-            }
-          }
           ...departmentFields
+        }
+        theme {
+          id
+          coverPhoto (resolution: "350X285") {
+            id
+            filename
+            url
+          }
         }
         status
       }

--- a/src/app/modules/consultations/consultation-profile/consultation-profile.component.html
+++ b/src/app/modules/consultations/consultation-profile/consultation-profile.component.html
@@ -1,5 +1,5 @@
 <div class="consultation-bg-img" appDefaultImage [type]="'consultation-cover'"
-[ngStyle]="profileData?.department?.theme?.coverPhoto?.url ? {'background-image': 'url(' + profileData?.department?.theme?.coverPhoto?.url + ')'} : null"></div>
+[ngStyle]="profileData?.theme?.coverPhoto?.url ? {'background-image': 'url(' + profileData?.theme?.coverPhoto?.url + ')'} : null"></div>
 <div class="consultation-profile">
   <aside class="consultation-profile__sidebar-section">
     <app-profile-card [profile]='profileData' [loading]="loading"></app-profile-card>

--- a/src/app/modules/consultations/consultation-profile/consultation-profile.graphql.ts
+++ b/src/app/modules/consultations/consultation-profile/consultation-profile.graphql.ts
@@ -118,19 +118,19 @@ export const ConsultationProfile = gql`
       consultationResponsesCount
       department {
         id
-        theme {
-          id
-          coverPhoto (resolution: "1500X750") {
-            id
-            filename
-            url
-          }
-        }
         name
         hindiName
         odiaName
         marathiName
         logo (resolution: "100X100") {
+          id
+          filename
+          url
+        }
+      }
+      theme {
+        id
+        coverPhoto (resolution: "1500X750") {
           id
           filename
           url
@@ -224,19 +224,19 @@ export const ConsultationProfileCurrentUser = gql`
       consultationResponsesCount
       department {
         id
-        theme {
-          id
-          coverPhoto (resolution: "1500X750") {
-            id
-            filename
-            url
-          }
-        }
         name
         hindiName
         odiaName
         marathiName
         logo (resolution: "100X100") {
+          id
+          filename
+          url
+        }
+      }
+      theme {
+        id
+        coverPhoto (resolution: "1500X750") {
           id
           filename
           url
@@ -332,19 +332,19 @@ export const ConsultationProfileUser = gql`
       consultationResponsesCount
       department {
         id
-        theme {
-          id
-          coverPhoto (resolution: "1500X750") {
-            id
-            filename
-            url
-          }
-        }
         name
         hindiName
         odiaName
         marathiName
         logo (resolution: "100X100") {
+          id
+          filename
+          url
+        }
+      }
+      theme {
+        id
+        coverPhoto (resolution: "1500X750") {
           id
           filename
           url

--- a/src/app/modules/consultations/consultation-profile/read-respond/read-respond.component.ts
+++ b/src/app/modules/consultations/consultation-profile/read-respond/read-respond.component.ts
@@ -204,10 +204,9 @@ export class ReadRespondComponent implements OnInit {
 
   createMetaTags(consultationProfile) {
     const title = consultationProfile.title ? consultationProfile.title : '' ;
-    const image = (consultationProfile['department'] ?
-    consultationProfile['department']['theme'] ?
-    (consultationProfile['department']['theme']['coverPhoto'] ?
-    consultationProfile['department']['theme']['coverPhoto']['url'] : '') : '' : '');
+    const image = (consultationProfile['theme'] ?
+    (consultationProfile['theme']['coverPhoto'] ?
+    consultationProfile['theme']['coverPhoto']['url'] : '') : '');
     const description = consultationProfile['summary'] ? (consultationProfile['summary'].length < 140 ?
                         consultationProfile['summary'] : consultationProfile['summary'].slice(0, 140)) : '';
     this.deleteMetaTags();

--- a/src/app/modules/consultations/consultations-summary/consultations-summary.graphql.ts
+++ b/src/app/modules/consultations/consultations-summary/consultations-summary.graphql.ts
@@ -47,15 +47,15 @@ export const ConsultationProfileQuery = gql`
       department {
         id
         name
-        theme {
-          id
-          coverPhoto (resolution: "350X285") {
-            id
-            filename
-            url
-          }
-        }
         logo (resolution: "100X100") {
+          id
+          filename
+          url
+        }
+      }
+      theme {
+        id
+        coverPhoto (resolution: "350X285") {
           id
           filename
           url

--- a/src/app/modules/consultations/response/response.component.html
+++ b/src/app/modules/consultations/response/response.component.html
@@ -1,5 +1,5 @@
 <div class="response-index"
-  [ngStyle]="{'background-image': 'url(' + profile?.consultation?.department?.theme?.coverPhoto?.url + ')'}">
+  [ngStyle]="{'background-image': 'url(' + profile?.consultation?.theme?.coverPhoto?.url + ')'}">
   <div class="response-profile">
     <section class="response-profile__sidebar-section">
       <div class="c-profile-card sticky">

--- a/src/app/modules/consultations/response/response.graphql.ts
+++ b/src/app/modules/consultations/response/response.graphql.ts
@@ -18,16 +18,16 @@ export const ResponseProfileQuery = gql`
                 consultationResponsesCount
                 department {
                   id
-                  theme {
-                    id
-                    coverPhoto (resolution: "350X285") {
-                      id
-                      filename
-                      url
-                    }
-                  }
                   name
                   logo (resolution: "100X100") {
+                    id
+                    filename
+                    url
+                  }
+                }
+                theme {
+                  id
+                  coverPhoto (resolution: "350X285") {
                     id
                     filename
                     url

--- a/src/app/shared/components/consultation-card/consultation-card.component.html
+++ b/src/app/shared/components/consultation-card/consultation-card.component.html
@@ -1,6 +1,6 @@
 <a href="javascript:void(0)" class="decoration-none" [routerLink]="['/consultations', consultation?.id]">
   <div class="consultation-card">
-    <div class="consultation-card__card-image" appDefaultImage appLazyLoad [type]="'consultation-cover'" [ngStyle]="consultation?.department?.theme?.coverPhoto?.url ? {'background-image': 'url(' + consultation?.department?.theme?.coverPhoto?.url + ')'} : null"></div>
+    <div class="consultation-card__card-image" appDefaultImage appLazyLoad [type]="'consultation-cover'" [ngStyle]="consultation?.theme?.coverPhoto?.url ? {'background-image': 'url(' + consultation?.theme?.coverPhoto?.url + ')'} : null"></div>
     <div class="consultation-card__details">
       <p class="title">{{ getConsultationTitle() }}</p>
       <p class="sub-title">{{ getDepartmentName() }}</p>


### PR DESCRIPTION
- Update GraphQL queries to fetch the theme directly from consultation instead of the department.theme
- Modify templates to reference consultation.theme instead of consultation.department.theme
- Adjust meta tag creation logic to use the new theme structure
- Update consultation card, list, and profile components to reflect the new data structure