### PR TITLE
feat: Fetch team members and advisory board dynamically from GraphQL API

### DIFF
--- a/src/app/modules/about-us/about-us.component.html
+++ b/src/app/modules/about-us/about-us.component.html
@@ -1,3 +1,17 @@
+<ng-template #memberListTemplate let-members="members">
+  <div class="members-list">
+    <ng-container *ngFor="let member of members">
+      <a [href]="member?.linkedinUrl" target="_blank" class="member-link long-description">
+        <div class="member-card">
+          <img [src]="member?.profilePicture?.url" [alt]="member?.name" />
+          <div class="name">{{ member?.name }}</div>
+          <div class="member-description">{{ member?.designation }}</div>
+        </div>
+      </a>
+    </ng-container>
+  </div>
+</ng-template>
+
 <div class="about-us-wrapper">
   <section>
     <h1>About Us</h1>
@@ -90,31 +104,11 @@
   <section class="team-section">
     <h1>The People Behind Civis</h1>
     <div class="title">The Team</div>
-    <div class="members-list">
-      <ng-container *ngFor="let teamMember of teamMembers">
-        <a [href]="teamMember?.linkedinUrl" target="_blank" class="member-link long-description">
-          <div class="member-card">
-            <img [src]="teamMember?.profilePicture?.url" [alt]="teamMember?.name" />
-            <div class="name">{{ teamMember?.name }}</div>
-            <div class="member-description">{{ teamMember?.designation }}</div>
-          </div>
-        </a>
-      </ng-container>
-    </div>
+    <ng-container *ngTemplateOutlet="memberListTemplate; context: { members: teamMembers }"></ng-container>
   </section>
   <section class="team-section">
     <div class="title">Advisory Board</div>
-    <div class="members-list">
-      <ng-container *ngFor="let advisor of advisors">
-        <a [href]="advisor?.linkedinUrl" target="_blank" class="member-link long-description">
-          <div class="member-card">
-            <img [src]="advisor?.profilePicture?.url" [alt]="advisor?.name" />
-            <div class="name">{{ advisor?.name }}</div>
-            <div class="member-description">{{ advisor?.designation }}</div>
-          </div>
-        </a>
-      </ng-container>
-    </div>
+    <ng-container *ngTemplateOutlet="memberListTemplate; context: { members: advisors }"></ng-container>
   </section>
   <section class="partners-section">
     <div class="title">PAST CONSULTATION PARTNERS</div>

--- a/src/app/modules/about-us/about-us.component.html
+++ b/src/app/modules/about-us/about-us.component.html
@@ -92,11 +92,25 @@
     <div class="title">The Team</div>
     <div class="members-list">
       <ng-container *ngFor="let teamMember of teamMembers">
-        <a [href]="teamMember.href" target="_blank" class="member-link" [ngClass]="teamMember.class">
+        <a [href]="teamMember?.linkedinUrl" target="_blank" class="member-link long-description">
           <div class="member-card">
-            <img [src]="teamMember.image" [alt]="teamMember.name" />
-            <div class="name">{{ teamMember.name }}</div>
-            <div class="member-description">{{ teamMember.description }}</div>
+            <img [src]="teamMember?.profilePicture?.url" [alt]="teamMember?.name" />
+            <div class="name">{{ teamMember?.name }}</div>
+            <div class="member-description">{{ teamMember?.designation }}</div>
+          </div>
+        </a>
+      </ng-container>
+    </div>
+  </section>
+  <section class="team-section">
+    <div class="title">Advisory Board</div>
+    <div class="members-list">
+      <ng-container *ngFor="let advisor of advisors">
+        <a [href]="advisor?.linkedinUrl" target="_blank" class="member-link long-description">
+          <div class="member-card">
+            <img [src]="advisor?.profilePicture?.url" [alt]="advisor?.name" />
+            <div class="name">{{ advisor?.name }}</div>
+            <div class="member-description">{{ advisor?.designation }}</div>
           </div>
         </a>
       </ng-container>

--- a/src/app/modules/about-us/about-us.component.ts
+++ b/src/app/modules/about-us/about-us.component.ts
@@ -1,11 +1,17 @@
 import { Component, OnInit } from "@angular/core";
+import { Apollo } from "apollo-angular";
+import { map } from "rxjs/operators";
+import { TeamMemberListQuery } from "./about-us.graphql";
 
 @Component({
   selector: "app-about-us",
   templateUrl: "./about-us.component.html",
   styleUrls: ["./about-us.component.scss"],
 })
-export class AboutUsComponent {
+export class AboutUsComponent implements OnInit {
+  teamMembers: [];
+  advisors: [];
+
   atCivisCards = [
     {
       text: "Aggregate all open laws seeking feedback",
@@ -36,75 +42,10 @@ export class AboutUsComponent {
     },
   ];
 
-  teamMembers = [
-    {
-      name: "Akalya V",
-      image: "assets/images/about-us/Akalya V.jpeg",
-      description: "Associate, Communications",
-      href: "https://www.linkedin.com/in/akalya-veerappan-b9b346203",
-      class: "long-description",
-    },
-    {
-      image: "assets/images/team/Alaksha-Dhakite.jpg",
-      name: "Alaksha Dhakite",
-      description: "Associate, Partnerships",
-      href: "https://www.linkedin.com/in/alaksha-dhakite-19822b164/",
-      class: "long-description",
-    },
-    {
-      name: "Antaraa Vasudev",
-      image: "assets/images/about-us/Antaraa Vasudev.jpeg",
-      description: "Founder & CEO",
-      href: "https://www.linkedin.com/in/antaraavasudev/",
-      class: "long-description",
-    },
-    {
-      name: "Atharva Joshi",
-      image: "assets/images/about-us/Atharva Joshi.jpeg",
-      description: "Senior Product Manager",
-      href: "https://www.linkedin.com/in/atharva-joshi-b80356153",
-      class: "long-description",
-    },
-    {
-      name: "Gargi Surana",
-      image: "assets/images/team/Gargi-Surana.jpg",
-      description: "Associate, Governance",
-      href: "https://www.linkedin.com/in/gargisurana/",
-      class: "long-description",
-    },
-    {
-      name: "Hetvi Chheda",
-      image: "assets/images/about-us/Hetvi Chheda.jpeg",
-      description: "Senior Associate, Governance",
-      href: "https://www.linkedin.com/in/hetvi-chheda-ab50b1192",
-      class: "long-description",
-    },
-    {
-      name: "Sukirat Kaur",
-      image: "assets/images/team/Sukirat-Kaur.jpg",
-      description: "Consultation Fellow",
-      href: "https://www.linkedin.com/in/sukirat-kaur-6a816820b/",
-      class: "long-description",
-    },
-    {
-      name: "Swetha A N",
-      image: "assets/images/team/Swetha-A-N.jpg",
-      description: "Administrative Officer",
-      href: "https://www.linkedin.com/in/swetha-anantha-narayanan-9511871b4/",
-      class: "long-description",
-    },
-    {
-      name: "Vagda Galhotra",
-      image: "assets/images/about-us/Vagda Galhotra.jpeg",
-      description: "Senior Associate, Outreach and Comms",
-      href: "https://www.linkedin.com/in/vagda-galhotra-320a04269",
-      class: "long-description",
-    },
-  ];
-
   pastPartners = [
     {
-      image: "assets/images/about-us/government-partners/1. Government of Maharashtra.jpg",
+      image:
+        "assets/images/about-us/government-partners/1. Government of Maharashtra.jpg",
       alt: "Government of Maharashtra",
     },
     {
@@ -116,31 +57,38 @@ export class AboutUsComponent {
       alt: "OCAC",
     },
     {
-      image: "assets/images/about-us/government-partners/4. Karmayogi Bharat.webp",
+      image:
+        "assets/images/about-us/government-partners/4. Karmayogi Bharat.webp",
       alt: "Karmayogi Bharat",
     },
     {
-      image: "assets/images/about-us/government-partners/5. Manipur State Rural Livelihoods Mission.png",
+      image:
+        "assets/images/about-us/government-partners/5. Manipur State Rural Livelihoods Mission.png",
       alt: "Manipur State Rural Livelihoods Mission",
     },
     {
-      image: "assets/images/about-us/government-partners/6. Securities and Exchange Board of India.png",
+      image:
+        "assets/images/about-us/government-partners/6. Securities and Exchange Board of India.png",
       alt: "Securities and Exchange Board of India",
     },
     {
-      image: "assets/images/about-us/government-partners/7. Maharashtra State Innovaiton Society.png",
+      image:
+        "assets/images/about-us/government-partners/7. Maharashtra State Innovaiton Society.png",
       alt: "Maharashtra State Innovation Society",
     },
     {
-      image: "assets/images/about-us/government-partners/8. Central Board of Secondary Education.png",
+      image:
+        "assets/images/about-us/government-partners/8. Central Board of Secondary Education.png",
       alt: "Central Board of Secondary Education",
     },
     {
-      image: "assets/images/about-us/government-partners/9. National Institute of Urban Affairs.png",
+      image:
+        "assets/images/about-us/government-partners/9. National Institute of Urban Affairs.png",
       alt: "National Institute of Urban Affairs",
     },
     {
-      image: "assets/images/about-us/government-partners/10. Supreme Court E-committee.png",
+      image:
+        "assets/images/about-us/government-partners/10. Supreme Court E-committee.png",
       alt: "Supreme Court E-committee",
     },
     {
@@ -180,4 +128,39 @@ export class AboutUsComponent {
       buttonText: "See our work",
     },
   ];
+
+  constructor(private apollo: Apollo) {}
+
+  ngOnInit() {
+    this.getTeamMembers();
+    this.getAdvisors();
+  }
+
+  getTeamMembers() {
+    this.apollo
+      .query({
+        query: TeamMemberListQuery,
+        variables: {
+          memberTypeFilter: "team",
+        },
+      })
+      .pipe(map((res: any) => res.data.teamMemberList.data))
+      .subscribe((teamMembers) => {
+        this.teamMembers = teamMembers.length ? teamMembers : null;
+      });
+  }
+
+  getAdvisors() {
+    this.apollo
+      .query({
+        query: TeamMemberListQuery,
+        variables: {
+          memberTypeFilter: "advisory",
+        },
+      })
+      .pipe(map((res: any) => res.data.teamMemberList.data))
+      .subscribe((advisors) => {
+        this.advisors = advisors.length ? advisors : null;
+      });
+  }
 }

--- a/src/app/modules/about-us/about-us.component.ts
+++ b/src/app/modules/about-us/about-us.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from "@angular/core";
 import { Apollo } from "apollo-angular";
 import { map } from "rxjs/operators";
 import { TeamMemberListQuery } from "./about-us.graphql";
+import { ErrorService } from "src/app/shared/components/error-modal/error.service";
 
 @Component({
   selector: "app-about-us",
@@ -129,7 +130,10 @@ export class AboutUsComponent implements OnInit {
     },
   ];
 
-  constructor(private apollo: Apollo) {}
+  constructor(
+    private apollo: Apollo,
+    private errorService: ErrorService,
+  ) {}
 
   ngOnInit() {
     this.getTeamMembers();
@@ -145,9 +149,14 @@ export class AboutUsComponent implements OnInit {
         },
       })
       .pipe(map((res: any) => res.data.teamMemberList.data))
-      .subscribe((teamMembers) => {
-        this.teamMembers = teamMembers.length ? teamMembers : null;
-      });
+      .subscribe(
+        (teamMembers) => {
+          this.teamMembers = teamMembers.length ? teamMembers : [];
+        },
+        (err) => {
+          this.errorService.showErrorModal(err);
+        },
+      );
   }
 
   getAdvisors() {
@@ -159,8 +168,13 @@ export class AboutUsComponent implements OnInit {
         },
       })
       .pipe(map((res: any) => res.data.teamMemberList.data))
-      .subscribe((advisors) => {
-        this.advisors = advisors.length ? advisors : null;
-      });
+      .subscribe(
+        (advisors) => {
+          this.advisors = advisors.length ? advisors : [];
+        },
+        (err) => {
+          this.errorService.showErrorModal(err);
+        },
+      );
   }
 }

--- a/src/app/modules/about-us/about-us.graphql.ts
+++ b/src/app/modules/about-us/about-us.graphql.ts
@@ -1,0 +1,21 @@
+import gql from "graphql-tag";
+
+export const TeamMemberListQuery = gql`
+  query TeamMemberList($memberTypeFilter: TeamMemberTypes) {
+    teamMemberList(memberTypeFilter: $memberTypeFilter) {
+      data {
+        id
+        name
+        designation
+        memberType
+        status
+        linkedinUrl
+        profilePicture(resolution: "200X200") {
+          id
+          filename
+          url
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
- Replace hardcoded team member data with a dynamic GraphQL query
- Add TeamMemberListQuery to fetch team members and advisors separately
- Update template to display team members and advisory board in separate sections
- Bind dynamic data fields (profilePicture.url, designation, linkedinUrl) in template
- Add the ngOnInit lifecycle hook to fetch data on component initialisation