### PR TITLE
fix: Prevent duplicate conditional questions in questionnaire by tracking seen child IDs

### DIFF
--- a/src/app/modules/consultations/consultation-profile/consultation-questionnaire/consultation-questionnaire.component.ts
+++ b/src/app/modules/consultations/consultation-profile/consultation-questionnaire/consultation-questionnaire.component.ts
@@ -1238,11 +1238,15 @@ export class ConsultationQuestionnaireComponent
     }
 
     const orderedChildren: any[] = [];
+    const seenChildIds = new Set<string>();
     parentQuestion.subQuestions.forEach((sq: any) => {
       const childId = sq?.conditionalQuestion?.id;
       if (childId) {
-        const child = idToQuestionMap[childId.toString()];
+        const childIdStr = childId.toString();
+        if (seenChildIds.has(childIdStr)) return;
+        const child = idToQuestionMap[childIdStr];
         if (child && child.isConditionalQuestion) {
+          seenChildIds.add(childIdStr);
           orderedChildren.push(child);
         }
       }


### PR DESCRIPTION
- Prevent duplicate conditional questions in questionnaire by tracking seen child IDs